### PR TITLE
Add from_args support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickparser"
-version = "0.1.1"
+version = "0.1.2"
 description = "Create lightweight CLI arg parsers from pydantic models"
 authors = [
     { name = "John Raines", email = "johndanielraines@gmail.com" }

--- a/src/quickparser/parser_tools.py
+++ b/src/quickparser/parser_tools.py
@@ -51,6 +51,18 @@ class Parser(Generic[T]):
         """
         return cls._parser.parse_args()
 
+    @classmethod
+    def from_args(cls):
+        """
+        Create an instance of the model from the parsed arguments.
+        """
+
+        args = cls.parse()
+        params = {}
+        for field_name, _ in cls._model.model_fields.items():
+            params[field_name] = getattr(args, field_name)
+
+        return cls._model(**params)
 
 def parser(cls=None, **kwargs) -> Parser[T]:
     """

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -139,17 +139,25 @@ class TestParser:
         assert args.is_strange is True
         assert args.favorite_color == "blue"
 
-    @patch("sys.argv", new=["test_parser.py", "--name", "Perry", "--age", "15", "--is-strange"])
+    @patch("sys.argv", new=["test_parser.py", "--last-name", "Lee", "--first-name", "Perry", "--age", "15", "--is-strange"])
     def test_parser_class_from_args(self, parser_cls):
         @pt.parser
         class Person(BaseModel):
-            name: str
+            last_name: str
+            first_name: str
             age: int
             is_strange: None | bool
 
+            @property
+            def full_name(self):
+                return f"{self.first_name} {self.last_name}"
+
         o = Person.from_args()
-        assert o.name == "Perry"
+        assert o.first_name == "Perry"
+        assert o.last_name == "Lee"
         assert o.age == 15
+        assert o.full_name == "Perry Lee"
+        assert o.is_strange is True
 
     def test_init_parser(self, parser_cls):
         """

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -139,6 +139,18 @@ class TestParser:
         assert args.is_strange is True
         assert args.favorite_color == "blue"
 
+    @patch("sys.argv", new=["test_parser.py", "--name", "Perry", "--age", "15", "--is-strange"])
+    def test_parser_class_from_args(self, parser_cls):
+        @pt.parser
+        class Person(BaseModel):
+            name: str
+            age: int
+            is_strange: None | bool
+
+        o = Person.from_args()
+        assert o.name == "Perry"
+        assert o.age == 15
+
     def test_init_parser(self, parser_cls):
         """
         Test the _init_parser function.


### PR DESCRIPTION
# Overview and use case

Create an object from the args out of the box. The logic can be used right away. 

```pythonn
@parser
class Person(BaseModel):
    last_name: str
    first_name: str
    age: int
    is_strange: None | bool

    @property
    def full_name(self):
        return f"{self.first_name} {self.last_name}"

if __name__ == "__main__":
    perry = Person.from_args()
    print(perry.full_name)
   
```